### PR TITLE
feat: add TableOfContents component to blog post template

### DIFF
--- a/src/components/callout-box/index.js
+++ b/src/components/callout-box/index.js
@@ -1,9 +1,25 @@
 import React from 'react'
-import { container as containerStyles } from './styles.module.css'
+import {
+  container as containerStyles,
+  blue as blueStyles,
+  orange as orangeStyles,
+} from './styles.module.css'
 
-const CalloutBox = ({ children }) => {
+const CalloutBox = ({ children, color = "blue" }) => {
+  let colorClassName;
+  switch (color) {
+    case "blue":
+      colorClassName = blueStyles
+      break
+    case "orange":
+      colorClassName = orangeStyles
+      break
+    default:
+      colorClassName = blueStyles
+  }
+
   return (
-    <aside className={containerStyles}>
+    <aside className={`${containerStyles} ${colorClassName}`}>
       {children}
     </aside>
   )

--- a/src/components/callout-box/styles.module.css
+++ b/src/components/callout-box/styles.module.css
@@ -1,7 +1,5 @@
 .container {
-  background-color: var(--light-blue);
   padding: 1rem;
-  border-left: 0.5rem solid var(--blue);
   margin: 1rem 3rem;
   overflow-wrap: break-word;
 }
@@ -18,4 +16,14 @@
 
 .container :last-child {
   margin-bottom: 0rem;
+}
+
+.blue {
+  background-color: var(--light-blue);
+  border-left: 0.5rem solid var(--blue);
+}
+
+.orange {
+  background-color: var(--light-orange);
+  border-left: 0.5rem solid var(--orange);
 }

--- a/src/components/header/components/nav-bar/index.js
+++ b/src/components/header/components/nav-bar/index.js
@@ -7,7 +7,7 @@ import {
 } from "./styles.module.css"
 
 const NavBar = () => (
-  <nav id="navigation">
+  <nav id="navigation" aria-label="Main Menu">
     <ul className={navBarStyles}>
       <li>
         <Link to="/" activeClassName={activeLinkStyles}>

--- a/src/components/table-of-contents/index.js
+++ b/src/components/table-of-contents/index.js
@@ -1,0 +1,55 @@
+import { Link } from 'gatsby'
+import React from 'react'
+
+import CalloutBox from '../callout-box'
+
+import {
+  tocWrapper as tocWrapperStyles,
+  heading as headingStyles,
+  link as linkStyles,
+} from "./styles.module.css"
+
+const ListItem = ({url, title, items}) => {
+  return (
+    <>
+      <li className={linkStyles}>
+        <Link to={url}>{title}</Link>
+      </li>
+      {
+        items != undefined && (
+          <ul>
+            {
+              items.map(({url, title, items}) => {
+                return <ListItem url={url} title={title} items={items} />
+              })
+            }
+          </ul>
+        )
+      }
+    </>
+  )
+}
+
+const TableOfContents = ({ tableOfContents }) => {
+  console.log(tableOfContents)
+  return (
+    <CalloutBox color="orange">
+      <nav aria-label="Table of Contents" className={tocWrapperStyles}>
+        <h2 className={headingStyles}>
+          Table of Contents
+        </h2>
+        <ul>
+        {
+          tableOfContents.items != undefined && (
+            tableOfContents?.items.map(({url, title, items}) => {
+              return <ListItem url={url} title={title} items={items} />
+            })
+          )
+        }
+        </ul>
+      </nav>
+    </CalloutBox>
+  )
+}
+
+export default TableOfContents

--- a/src/components/table-of-contents/styles.module.css
+++ b/src/components/table-of-contents/styles.module.css
@@ -1,0 +1,16 @@
+.toc-wrapper {
+  background-color: var(--light-orange);
+}
+
+.heading {
+  margin-bottom: 1rem;
+}
+
+.link a {
+  line-height: 1.75;
+  border-bottom-color: var(--orange);
+}
+
+.link a:hover, .link a:focus {
+  border-bottom-color: var(--blue);
+}

--- a/src/templates/blog-post.js
+++ b/src/templates/blog-post.js
@@ -4,6 +4,7 @@ import { graphql } from "gatsby"
 import Layout from "../components/layout"
 import RouteTargetHeading from "../components/route-target-heading"
 import MDXProvider from "../components/mdx-provider"
+import TableOfContents from "../components/table-of-contents"
 import MailingListSignupForm from "../components/mailing-list-signup-form"
 
 import {
@@ -25,6 +26,7 @@ export const query = graphql`
           minutesRoundedUp
         }
       }
+      tableOfContents
     }
   }
 `
@@ -47,6 +49,7 @@ const BlogPost = ({ data, location, children }) => {
       <p
         className={timeToReadStyles}
       >{`(${data.mdx.fields.timeToRead.minutesRoundedUp}-minute read)`}</p>
+      <TableOfContents tableOfContents={data.mdx.tableOfContents} />
       <MDXProvider>{children}</MDXProvider>
       <MailingListSignupForm />
     </Layout>


### PR DESCRIPTION
Closes #107.

- [ ] Bug: Headings with backticks (`) in the text return weird titles. See `/blog/managing-focus-with-react-and-jest/`
- [ ] Bug: Clicking a link in the Table of Contents doesn't actually move me down to the correct heading, because the RouteTargetHeading link takes over and moves me back up to the top of the page.